### PR TITLE
Moved logos from Metadata to default screen parts

### DIFF
--- a/docassemble/ILAO/data/questions/default-home.yml
+++ b/docassemble/ILAO/data/questions/default-home.yml
@@ -2,8 +2,6 @@ metadata:
   title url: https://www.illinoislegalaid.org 
   title: ILAO Easy Forms
   short title: ILAO Easy Forms
-  logo: |
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Muli"><img src="/packagestatic/docassemble.ILAO/ilao.logo.noname.25.png" class="ilao_icon" alt="ILAO Icon"><h1 style="display:inline; font-family: 'Muli'; margin:10px;font-size:20px;color:#fff">Easy Forms</h1>
 ---
 modules:
   - .toolbox
@@ -19,6 +17,8 @@ features:
   css: ilao_theme.css
 ---
 default screen parts:
+  logo: |
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Muli"><img src="/packagestatic/docassemble.ILAO/ilao.logo.noname.25.png" class="ilao_icon" alt="ILAO Icon"><h1 style="display:inline; font-family: 'Muli'; margin:10px;font-size:20px;color:#fff">Easy Forms</h1>
   under: |
     Questions or comments? [Contact ILAO](https://www.illinoislegalaid.org/contact-us).
 ---

--- a/docassemble/ILAO/data/questions/feedback.yml
+++ b/docassemble/ILAO/data/questions/feedback.yml
@@ -1,8 +1,6 @@
 metadata:
   title: Feedback
   short title: Feedback
-  logo: |
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Muli"><img src="/packagestatic/docassemble.ILAO/ilao.logo.noname.25.png" class="ilao_icon" alt="ILAO Icon"><h1 style="display:inline; font-family: 'Muli'; margin:10px;font-size:20px;color:#fff">Feedback</h1>
 ---
 include:
   - docassemble.ILAO:shared-basic-questions.yml
@@ -15,6 +13,8 @@ features:
   css: ilao_theme.css
 ---
 default screen parts:
+  logo: |
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Muli"><img src="/packagestatic/docassemble.ILAO/ilao.logo.noname.25.png" class="ilao_icon" alt="ILAO Icon"><h1 style="display:inline; font-family: 'Muli'; margin:10px;font-size:20px;color:#fff">Feedback</h1>
   under: |
     If you have more to say, [**contact ILAO**](https://www.illinoislegalaid.org/contact-us).
 ---

--- a/docassemble/ILAO/data/questions/ilao-interview-framework.yml
+++ b/docassemble/ILAO/data/questions/ilao-interview-framework.yml
@@ -1,8 +1,6 @@
 metadata:
   title url: https://www.illinoislegalaid.org 
   exit url: https://www.illinoislegalaid.org
-  logo: |
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Muli"><img src="/packagestatic/docassemble.ILAO/ilao.logo.noname.25.png" class="ilao_icon" alt="ILAO Icon"><h1 style="display:inline; font-family: 'Muli'; margin:10px;font-size:20px;color:#fff">Easy Form</h1>
 ---
 modules:
   - .toolbox
@@ -18,6 +16,8 @@ features:
     - ilao_docs_table.css
 ---
 default screen parts:
+  logo: |
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Muli"><img src="/packagestatic/docassemble.ILAO/ilao.logo.noname.25.png" class="ilao_icon" alt="ILAO Icon"><h1 style="display:inline; font-family: 'Muli'; margin:10px;font-size:20px;color:#fff">Easy Form</h1>
   corner back button label: |
     Back
   back button label: |


### PR DESCRIPTION
Fixes a breaking change made in AssemblyLine 2.7 that would override logos of other packages.This fixes it and goes back to the original logo.