### PR TITLE
Add alt text to the logo image in the menu bar

### DIFF
--- a/docassemble/ILAO/data/questions/default-home.yml
+++ b/docassemble/ILAO/data/questions/default-home.yml
@@ -24,7 +24,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -34,7 +34,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/default-home.yml
+++ b/docassemble/ILAO/data/questions/default-home.yml
@@ -24,7 +24,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -34,7 +34,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/default-home.yml
+++ b/docassemble/ILAO/data/questions/default-home.yml
@@ -24,7 +24,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -34,7 +34,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/feedback.yml
+++ b/docassemble/ILAO/data/questions/feedback.yml
@@ -20,7 +20,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -30,7 +30,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/feedback.yml
+++ b/docassemble/ILAO/data/questions/feedback.yml
@@ -20,7 +20,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -30,7 +30,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/feedback.yml
+++ b/docassemble/ILAO/data/questions/feedback.yml
@@ -20,7 +20,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="ILAO logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -30,7 +30,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="ILAO logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/ilao-interview-framework.yml
+++ b/docassemble/ILAO/data/questions/ilao-interview-framework.yml
@@ -25,7 +25,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -35,7 +35,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/ilao-interview-framework.yml
+++ b/docassemble/ILAO/data/questions/ilao-interview-framework.yml
@@ -25,7 +25,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -35,7 +35,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/ilao-interview-framework.yml
+++ b/docassemble/ILAO/data/questions/ilao-interview-framework.yml
@@ -25,7 +25,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('title','').rstrip() }</div>
@@ -35,7 +35,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="Illinois Legal Aid Online's Logo">
+        <img src="/packagestatic/docassemble.ILAO/logo_white_30.svg" alt="">
       </div>
       <div class="al-title">
         <div class="title-row-1">${ all_variables(special='metadata').get('short title','').rstrip() }</div>

--- a/docassemble/ILAO/data/questions/ilao_interview_list.yml
+++ b/docassemble/ILAO/data/questions/ilao_interview_list.yml
@@ -33,7 +33,7 @@ features:
     - interview_list.css     
 ---
 code: |
-  al_logo.alt_text = ""
+  al_logo.alt_text = "Illinois Legal Aid Online"
   # AL_ORGANIZATION_TITLE assigned here to overwrite CourtFormsOnline
   AL_ORGANIZATION_TITLE = "ILAO Easy Forms"
 ---

--- a/docassemble/ILAO/data/questions/ilao_interview_list.yml
+++ b/docassemble/ILAO/data/questions/ilao_interview_list.yml
@@ -33,7 +33,7 @@ features:
     - interview_list.css     
 ---
 code: |
-  al_logo.alt_text = "ILAO Logo"
+  al_logo.alt_text = ""
   # AL_ORGANIZATION_TITLE assigned here to overwrite CourtFormsOnline
   AL_ORGANIZATION_TITLE = "ILAO Easy Forms"
 ---


### PR DESCRIPTION
This makes sure that users using screen readers are able to understand what the image is of.

Based off of suggestions from [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#icons_or_logos), which says to add simple alt text for logos. I tried using `ILAO`, but sometimes screen readers didn't know how to pronounce it and said seemingly gibberish.