### PR TITLE
Use `al_name_suffixes` instead of `name_suffix()` for forward compatibility with AL 4.0.0

### DIFF
--- a/docassemble/ILAO/data/questions/shared-basic-questions.yml
+++ b/docassemble/ILAO/data/questions/shared-basic-questions.yml
@@ -82,7 +82,7 @@ fields:
   - Last name: user.name.last
   - Suffix: user.name.suffix
     code: |
-      name_suffix()
+      al_name_suffixes
     required: False  
 ---
 id: your birthdate
@@ -367,3 +367,16 @@ generic object: ALAddress
 template: x.postal_code_label
 content: |
   ZIP code
+
+---
+variable name: al_name_suffixes
+data:
+  - Jr
+  - Junior
+  - Sr
+  - Senior
+  - II
+  - III
+  - IV
+  - V
+  - VI


### PR DESCRIPTION
AssemblyLine release 4.0.0 no longer uses `name_suffix()` in the `name_fields()` method; instead it uses a variable `al_name_suffixes`.

This leaves the current `update_language_function()` in place but also defines `al_name_suffixes` to ILAO's standard list of suffixes. It also updates explicit uses of `name_suffix()` to `al_name_suffixes`.

Can be merged without waiting for installation of AL 4.0.0 on your servers as this is backwards compatible with both methods.