### PR TITLE
Make sure the params we pass to `interview_url` don't break the HTML

### DIFF
--- a/docassemble/ILAO/data/questions/shared-basic-questions.yml
+++ b/docassemble/ILAO/data/questions/shared-basic-questions.yml
@@ -1,4 +1,7 @@
 ---
+imports:
+  - urllib.parse
+---
 objects:
   - form: DADict
   - user: Individual
@@ -6,7 +9,6 @@ objects:
   - court_list: ALCourtLoader.using(file_name='docassemble.ILAO:data/sources/il_courts.xlsx')
   - landlord: ALIndividual
   - property_manager: ALIndividual
-
 ---
 terms: 
 # old terms below - question-circle icons removed
@@ -293,7 +295,7 @@ subquestion: |
   You can try one of these steps to recover your work:
   
   * Click **Back** and try again,
-  * [:comment-dots: **Tell us what happened**](${ interview_url(i="docassemble.ILAO:feedback.yml", easy_form_interview=ilao_easy_form_url , easy_form_title=ilao_easy_form_title, easy_form_page=current_context().question_id, easy_form_variable=current_context().variable, easy_form_error_message=action_argument('error_message'), local=False,reset=1) }){target="_blank"}, or
+  * [:comment-dots: **Tell us what happened**](${ interview_url(i="docassemble.ILAO:feedback.yml", easy_form_interview=ilao_easy_form_url , easy_form_title=ilao_easy_form_title, easy_form_page=current_context().question_id, easy_form_variable=current_context().variable, easy_form_error_message=urllib.parse.quote(str(action_argument('error_message')), safe=''), local=False,reset=1) }){target="_blank"}, or
   * Visit the [**ILAO Form Library**](https://www.illinoislegalaid.org/form-library) and try another Easy Form.
   
   ${ collapse_template(al_formatted_error_message) }


### PR DESCRIPTION
Use the python builtin `urllib.parse` to make sure the error message doesn't have quotes that later break the HTML on the page, fixing broken URLs that expand past their anchor link.

<img width="568" height="303" alt="Screenshot 2025-11-21 at 12 46 41 PM" src="https://github.com/user-attachments/assets/d5100d71-9aa8-4566-ad92-ca8a6b081652" />
