### PR TITLE
Return '' instead of `None` when no error message

### DIFF
--- a/docassemble/ILAO/data/questions/feedback.yml
+++ b/docassemble/ILAO/data/questions/feedback.yml
@@ -4,6 +4,24 @@ metadata:
   title url: https://www.illinoislegalaid.org 
   exit url: https://www.illinoislegalaid.org
 ---
+# Replace the default error action to not give a link to this same feedback interview
+id: custom error action
+event: al_custom_error_action
+decoration: bug
+question: |
+  Something went wrong
+subquestion: |
+  We ran into an error when we tried to load this screen.
+  You can try one of these steps to recover your work:
+  
+  * Click **Back** and try again,
+  * Visit the [**ILAO Form Library**](https://www.illinoislegalaid.org/form-library) and try another Easy Form.
+  
+  ${ collapse_template(al_formatted_error_message) }
+buttons:
+  - Exit: exit
+  - Restart: restart
+---
 include:
   - docassemble.AssemblyLine:assembly_line.yml
   - docassemble.ILAO:shared-basic-questions.yml

--- a/docassemble/ILAO/data/questions/feedback.yml
+++ b/docassemble/ILAO/data/questions/feedback.yml
@@ -114,7 +114,8 @@ content: |
   
   Variable sought (if any): ${ url_args.get('easy_form_variable') }
 
-  Error message: ${ url_args.get('easy_form_error_message') } 
+  Error message: ${ urllib.parse.unquote(url_args.get('easy_form_error_message', '')) }
+ 
 ---
 code: |
   email_sent_ok = send_email(to="formsupport@illinoislegalaid.org", template=forms_email)

--- a/docassemble/ILAO/data/questions/shared-basic-questions.yml
+++ b/docassemble/ILAO/data/questions/shared-basic-questions.yml
@@ -302,7 +302,6 @@ subquestion: |
 buttons:
   - Exit: exit
   - Restart: restart
-  
 ---
 template: al_formatted_error_message
 subject: |


### PR DESCRIPTION
`urllib.parse.unquote` assumes that you pass it a string, and will error if you pass it `None`. This prevents `None` from being passed to that function (which happens when users try to give feedback without seeing an error first).